### PR TITLE
[WIP] Refactor examples CMakeLists

### DIFF
--- a/asio/src/examples/cpp11/CMakeLists.txt
+++ b/asio/src/examples/cpp11/CMakeLists.txt
@@ -1,62 +1,63 @@
 set(target_prefix asio_cpp11_)
 
 set(noinst_PROGRAMS
-  allocation/server.cpp
-  buffers/reference_counted.cpp
-  chat/chat_client.cpp
-  chat/chat_server.cpp
-  echo/async_tcp_echo_server.cpp
-  echo/async_udp_echo_server.cpp
-  echo/blocking_tcp_echo_client.cpp
-  echo/blocking_tcp_echo_server.cpp
-  echo/blocking_udp_echo_client.cpp
-  echo/blocking_udp_echo_server.cpp
-  executors/actor.cpp
-  executors/bank_account_1.cpp
-  executors/bank_account_2.cpp
-  executors/fork_join.cpp
-  executors/pipeline.cpp
-  executors/priority_scheduler.cpp
-  fork/daemon.cpp
-  fork/process_per_connection.cpp
-  futures/daytime_client.cpp
-  invocation/prioritised_handlers.cpp
-  iostreams/http_client.cpp
-  local/connect_pair.cpp
-  local/iostream_client.cpp
-  local/stream_client.cpp
-  local/stream_server.cpp
-  multicast/receiver.cpp
-  multicast/sender.cpp
-  nonblocking/third_party_lib.cpp
-  operations/composed_1.cpp
-  operations/composed_2.cpp
-  operations/composed_3.cpp
-  operations/composed_4.cpp
-  operations/composed_5.cpp
-  operations/composed_6.cpp
-  operations/composed_7.cpp
-  operations/composed_8.cpp
-  socks4/sync_client.cpp
-  timeouts/async_tcp_client.cpp
-  timeouts/blocking_tcp_client.cpp
-  timeouts/blocking_token_tcp_client.cpp
-  timeouts/blocking_udp_client.cpp
-  timeouts/server.cpp
-  timers/time_t_timer.cpp
+  allocation/server
+  buffers/reference_counted
+  chat/chat_client
+  chat/chat_server
+  echo/async_tcp_echo_server
+  echo/async_udp_echo_server
+  echo/blocking_tcp_echo_client
+  echo/blocking_tcp_echo_server
+  echo/blocking_udp_echo_client
+  echo/blocking_udp_echo_server
+  executors/actor
+  executors/bank_account_1
+  executors/bank_account_2
+  executors/fork_join
+  executors/pipeline
+  executors/priority_scheduler
+  fork/daemon
+  fork/process_per_connection
+  futures/daytime_client
+  http/server/http_server
+  invocation/prioritised_handlers
+  iostreams/http_client
+  local/connect_pair
+  local/iostream_client
+  local/stream_client
+  local/stream_server
+  multicast/receiver
+  multicast/sender
+  nonblocking/third_party_lib
+  operations/composed_1
+  operations/composed_2
+  operations/composed_3
+  operations/composed_4
+  operations/composed_5
+  operations/composed_6
+  operations/composed_7
+  operations/composed_8
+  socks4/sync_client
+  timeouts/async_tcp_client
+  timeouts/blocking_tcp_client
+  timeouts/blocking_token_tcp_client
+  timeouts/blocking_udp_client
+  timeouts/server
+  timers/time_t_timer
 )
 
 if(Boost_FOUND)
   set(noinst_PROGRAMS ${noinst_PROGRAMS}
-    spawn/echo_server.cpp
-    spawn/parallel_grep.cpp
+    spawn/echo_server
+    spawn/parallel_grep
   )
 endif()
 
 if(OpenSSL_FOUND)
   set(noinst_PROGRAMS ${noinst_PROGRAMS}
-    ssl/client.cpp
-    ssl/server.cpp
+    ssl/client
+    ssl/server
   )
 endif()
 
@@ -71,10 +72,12 @@ set(http_server_http_server_SOURCES
   http/server/server.cpp
 )
 
-foreach(source ${noinst_PROGRAMS})
-  string(REGEX REPLACE "\.cpp$" "" program ${source} )
+foreach(program ${noinst_PROGRAMS})
   string(REPLACE "/" "_" target ${program})
-  add_executable(${target_prefix}${target} ${source} ${${target}_SOURCES})
+  if(NOT DEFINED "${target}_SOURCES")
+    set("${target}_SOURCES" ${program})
+  endif()
+  add_executable(${target_prefix}${target} ${${target}_SOURCES})
   set_target_properties(${target_prefix}${target} PROPERTIES CXX_STANDARD 11)
   target_link_libraries(${target_prefix}${target} asio::standalone)
 


### PR DESCRIPTION
This adds target `asio_cpp11_http_server_http_server` and make the `CMakeLists.txt` more consistent with cpp03 examples. Similar changes can be done for cpp14 and cpp17 examples. Futhermore this approach allows removing lines in cpp03 examples `CMakeLists.txt` where the target depends on one cpp file only.